### PR TITLE
All classes connected with REST API moved to package ru.gwp.api

### DIFF
--- a/src/main/java/ru/gwp/api/BaseRestApi.java
+++ b/src/main/java/ru/gwp/api/BaseRestApi.java
@@ -1,9 +1,9 @@
 package ru.gwp.api;
 
+import ru.gwp.api.constants.ContentType;
 import ru.gwp.api.rest.RestRequest;
-import ru.gwp.constants.ContentType;
 
-import static ru.gwp.constants.ContentType.JSON;
+import static ru.gwp.api.constants.ContentType.JSON;
 
 /** Provides functionality to work with REST API. */
 public interface BaseRestApi {

--- a/src/main/java/ru/gwp/api/constants/ContentType.java
+++ b/src/main/java/ru/gwp/api/constants/ContentType.java
@@ -1,4 +1,4 @@
-package ru.gwp.constants;
+package ru.gwp.api.constants;
 
 import lombok.Getter;
 

--- a/src/main/java/ru/gwp/api/constants/LogLevel.java
+++ b/src/main/java/ru/gwp/api/constants/LogLevel.java
@@ -1,4 +1,4 @@
-package ru.gwp.constants;
+package ru.gwp.api.constants;
 
 import lombok.Getter;
 import ru.gwp.error.AutoTestError;

--- a/src/main/java/ru/gwp/api/constants/RequestMethod.java
+++ b/src/main/java/ru/gwp/api/constants/RequestMethod.java
@@ -1,4 +1,4 @@
-package ru.gwp.constants;
+package ru.gwp.api.constants;
 
 import lombok.Getter;
 

--- a/src/main/java/ru/gwp/api/junit/AllureRestAssuredBeforeAll.java
+++ b/src/main/java/ru/gwp/api/junit/AllureRestAssuredBeforeAll.java
@@ -1,4 +1,4 @@
-package ru.gwp.junit;
+package ru.gwp.api.junit;
 
 import io.qameta.allure.restassured.AllureRestAssured;
 import org.junit.jupiter.api.extension.BeforeAllCallback;

--- a/src/main/java/ru/gwp/api/rest/RestRequest.java
+++ b/src/main/java/ru/gwp/api/rest/RestRequest.java
@@ -1,7 +1,7 @@
 package ru.gwp.api.rest;
 
-import ru.gwp.constants.ContentType;
-import ru.gwp.constants.RequestMethod;
+import ru.gwp.api.constants.ContentType;
+import ru.gwp.api.constants.RequestMethod;
 
 /** Provides functionality to work with REST request. */
 public interface RestRequest {

--- a/src/main/java/ru/gwp/api/rest/restAssured/RestAssuredRequest.java
+++ b/src/main/java/ru/gwp/api/rest/restAssured/RestAssuredRequest.java
@@ -6,13 +6,13 @@ import io.restassured.builder.RequestSpecBuilder;
 import lombok.Getter;
 import ru.gwp.api.rest.RestRequest;
 import ru.gwp.api.rest.RestResponse;
-import ru.gwp.constants.ContentType;
-import ru.gwp.constants.LogLevel;
-import ru.gwp.constants.RequestMethod;
+import ru.gwp.api.constants.ContentType;
+import ru.gwp.api.constants.LogLevel;
+import ru.gwp.api.constants.RequestMethod;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static lombok.AccessLevel.PACKAGE;
-import static ru.gwp.constants.LogLevel.fromString;
+import static ru.gwp.api.constants.LogLevel.fromString;
 
 /**
  * Provides implementation of functionality to work with REST request. Wraps RestAssured methods

--- a/src/main/java/ru/gwp/api/rest/restAssured/RestAssuredResponse.java
+++ b/src/main/java/ru/gwp/api/rest/restAssured/RestAssuredResponse.java
@@ -4,13 +4,12 @@ import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.hamcrest.Matcher;
-import ru.gwp.api.rest.RestRequest;
 import ru.gwp.api.rest.RestResponse;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.restassured.RestAssured.given;
 import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
-import static ru.gwp.constants.LogLevel.DEBUG;
+import static ru.gwp.api.constants.LogLevel.DEBUG;
 
 /** Provides implementation of functionality to work with REST response. */
 public final class RestAssuredResponse implements RestResponse {

--- a/src/main/java/ru/gwp/api/steps/BaseApiSteps.java
+++ b/src/main/java/ru/gwp/api/steps/BaseApiSteps.java
@@ -1,4 +1,4 @@
-package ru.gwp.steps.api;
+package ru.gwp.api.steps;
 
 /** Provides base steps to work with REST API. */
 public interface BaseApiSteps {

--- a/src/main/java/ru/gwp/api/steps/BaseApiStepsImpl.java
+++ b/src/main/java/ru/gwp/api/steps/BaseApiStepsImpl.java
@@ -1,4 +1,4 @@
-package ru.gwp.steps.api;
+package ru.gwp.api.steps;
 
 import ru.gwp.error.AutoTestError;
 


### PR DESCRIPTION
[=] BaseApiSteps.java and BaseApiStepsImpl.java
[=] ContentType.java, LogLevel.java, RequestMethod.java and Header.java
[=] BaseRestApi.java
[=] AllureRestAssuredBeforeAll.java
[=] RestRequest.java and RestAssuredRequest.java
[=] RestAssuredResponse.java
[=] TheCatApiImpl.java, TheCatApiSteps.java, TheCatApiStepsImpl.java and TheCatApiTest.java